### PR TITLE
Implement shared access checks for pin endpoints

### DIFF
--- a/routes/prompts/templates/pin_template.py
+++ b/routes/prompts/templates/pin_template.py
@@ -2,6 +2,7 @@ from fastapi import Depends, HTTPException
 from models.common import APIResponse
 from utils import supabase_helpers
 from .helpers import router, supabase
+from utils.access_control import user_has_access_to_template
 
 @router.post("/pin/{template_id}")
 async def pin_template_v2(
@@ -9,46 +10,11 @@ async def pin_template_v2(
     user_id: str = Depends(supabase_helpers.get_user_from_session_token),
 ) -> APIResponse[dict]:
     """Pin a template using the pinned_template_ids field."""
-    #try:
-        # Verify template exists and user has access
-    template_resp = (
-        supabase.table("prompt_templates")
-        .select("*")
-        .eq("id", template_id)
-        .single()
-        .execute()
-    )
-    if not template_resp.data:
+    access = user_has_access_to_template(supabase, user_id, template_id)
+    if access is None:
         raise HTTPException(status_code=404, detail="Template not found")
-
-    template = template_resp.data
-    template_type = template.get("type", "user")
-
-    if template_type == "user" and template.get("user_id") != user_id:
+    if not access:
         raise HTTPException(status_code=403, detail="Access denied to this template")
-    elif template_type == "company":
-        metadata_resp = (
-            supabase.table("users_metadata")
-            .select("company_id")
-            .eq("user_id", user_id)
-            .single()
-            .execute()
-        )
-        if not metadata_resp.data or metadata_resp.data.get("company_id") != template.get("company_id"):
-            raise HTTPException(status_code=403, detail="Access denied to this company template")
-    elif template_type == "organization":
-        metadata_resp = (
-            supabase.table("users_metadata")
-            .select("organization_ids")
-            .eq("user_id", user_id)
-            .single()
-            .execute()
-        )
-        if not metadata_resp.data:
-            raise HTTPException(status_code=403, detail="Access denied to this organization template")
-        org_ids = metadata_resp.data.get("organization_ids", [])
-        if template.get("organization_id") not in org_ids:
-            raise HTTPException(status_code=403, detail="Access denied to this organization template")
 
     # Get current pinned template ids
     user_meta_resp = (

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -287,19 +287,7 @@ def test_pin_template(test_client, mock_supabase, valid_auth_header, mock_authen
     """Test pinning a template using the pinned_template_ids field."""
 
     def table_side_effect(table_name):
-        if table_name == "prompt_templates":
-            table_mock = MagicMock()
-            select_mock = MagicMock()
-            eq_mock = MagicMock()
-            single_mock = MagicMock()
-            execute_mock = MagicMock()
-            execute_mock.data = {"id": 1, "type": "user", "user_id": mock_authenticate_user}
-            table_mock.select.return_value = select_mock
-            select_mock.eq.return_value = eq_mock
-            eq_mock.single.return_value = single_mock
-            single_mock.execute.return_value = execute_mock
-            return table_mock
-        elif table_name == "users_metadata":
+        if table_name == "users_metadata":
             table_mock = MagicMock()
             select_mock = MagicMock()
             eq_mock = MagicMock()
@@ -326,7 +314,8 @@ def test_pin_template(test_client, mock_supabase, valid_auth_header, mock_authen
 
     mock_supabase["templates"].table.side_effect = table_side_effect
 
-    with patch('routes.prompts.templates.helpers.supabase', mock_supabase["templates"]):
+    with patch('routes.prompts.templates.helpers.supabase', mock_supabase["templates"]), \
+         patch('routes.prompts.templates.pin_template.user_has_access_to_template', return_value=True):
         response = test_client.post("/prompts/templates/pin/1", headers=valid_auth_header)
 
     assert response.status_code == 200

--- a/tests/test_prompts_folders.py
+++ b/tests/test_prompts_folders.py
@@ -130,8 +130,9 @@ def test_pin_folder(test_client, mock_supabase, valid_auth_header, mock_authenti
     updated_pinned_folders = [1, 2]
     
     # Directly patch the function calls in the route
-    with patch('routes.prompts.folders.get_user_pinned_folders') as mock_get_pinned, \
-         patch('routes.prompts.folders.update_user_pinned_folders') as mock_update_pinned:
+    with patch('utils.prompts.folders.get_user_pinned_folders') as mock_get_pinned, \
+         patch('utils.prompts.folders.update_user_pinned_folders') as mock_update_pinned, \
+         patch('routes.prompts.folders.pin_folder.user_has_access_to_folder', return_value=True):
         
         # Setup mock responses
         mock_get_pinned.return_value = mock_pinned_folders
@@ -159,8 +160,8 @@ def test_unpin_folder(test_client, mock_supabase, valid_auth_header, mock_authen
     updated_pinned_folders = [2]
     
     # Directly patch the function calls in the route
-    with patch('routes.prompts.folders.get_user_pinned_folders') as mock_get_pinned, \
-         patch('routes.prompts.folders.update_user_pinned_folders') as mock_update_pinned:
+    with patch('utils.prompts.folders.get_user_pinned_folders') as mock_get_pinned, \
+         patch('utils.prompts.folders.update_user_pinned_folders') as mock_update_pinned:
         
         # Setup mock responses
         mock_get_pinned.return_value = mock_pinned_folders

--- a/utils/access_control.py
+++ b/utils/access_control.py
@@ -1,4 +1,5 @@
 from supabase import Client
+from typing import Optional
 
 
 def get_user_metadata(supabase: Client, user_id: str) -> dict:
@@ -37,3 +38,59 @@ def apply_access_conditions(query, supabase: Client, user_id: str):
     if conditions:
         query = query.or_(",".join(conditions))
     return query
+
+
+def user_has_access_to_folder(supabase: Client, user_id: str, folder_id: int) -> Optional[bool]:
+    """Return True if user has access to the folder, False if not, None if folder doesn't exist."""
+    resp = (
+        supabase.table("prompt_folders")
+        .select("user_id, company_id, organization_id")
+        .eq("id", folder_id)
+        .single()
+        .execute()
+    )
+
+    folder = resp.data
+    if not folder:
+        return None
+
+    metadata = get_user_metadata(supabase, user_id)
+
+    if folder.get("user_id"):
+        return folder.get("user_id") == user_id
+
+    if folder.get("company_id"):
+        return folder.get("company_id") == metadata.get("company_id")
+
+    if folder.get("organization_id"):
+        return folder.get("organization_id") in (metadata.get("organization_ids") or [])
+
+    return True
+
+
+def user_has_access_to_template(supabase: Client, user_id: str, template_id: int) -> Optional[bool]:
+    """Return True if user has access to the template, False if not, None if template doesn't exist."""
+    resp = (
+        supabase.table("prompt_templates")
+        .select("user_id, company_id, organization_id")
+        .eq("id", template_id)
+        .single()
+        .execute()
+    )
+
+    template = resp.data
+    if not template:
+        return None
+
+    metadata = get_user_metadata(supabase, user_id)
+
+    if template.get("user_id"):
+        return template.get("user_id") == user_id
+
+    if template.get("company_id"):
+        return template.get("company_id") == metadata.get("company_id")
+
+    if template.get("organization_id"):
+        return template.get("organization_id") in (metadata.get("organization_ids") or [])
+
+    return True


### PR DESCRIPTION
## Summary
- centralize folder/template access logic in `utils/access_control`
- update `pin_folder` and `pin_template` to use new helpers
- adjust tests to patch the new access helpers

## Testing
- `pytest -q` *(fails: Invalid API key)*

------
https://chatgpt.com/codex/tasks/task_b_685bd24f62a483259a89c3539b97a19b