### PR TITLE
Validate Stripe URLs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,12 @@ from fastapi.testclient import TestClient
 os.environ.setdefault("SUPABASE_URL", "http://localhost")
 os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "eyJhbGciOiJIUzI1NiJ9.fake.fake")
 
+# Provide dummy Stripe configuration so Stripe service can initialize during tests
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test_123")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
+os.environ.setdefault("STRIPE_MONTHLY_PRICE_ID", "price_monthly")
+os.environ.setdefault("STRIPE_YEARLY_PRICE_ID", "price_yearly")
+
 from main import app
 
 @pytest.fixture

--- a/tests/test_stripe.py
+++ b/tests/test_stripe.py
@@ -1,0 +1,37 @@
+import pytest
+from unittest.mock import patch
+import utils.auth
+
+
+def _request_data(user_id):
+    return {
+        "priceId": "price_123",
+        "successUrl": "http://example.com/success",
+        "cancelUrl": "http://example.com/cancel",
+        "userId": user_id,
+        "userEmail": "user@example.com",
+    }
+
+
+def test_invalid_success_url_scheme(test_client, mock_supabase, valid_auth_header, mock_authenticate_user):
+    data = _request_data(mock_authenticate_user)
+    data["successUrl"] = "ftp://bad.url"
+    test_client.app.dependency_overrides[utils.auth.get_current_user] = lambda: mock_authenticate_user
+    with patch('routes.stripe.create_checkout_session.stripe_service.create_checkout_session') as mock_service:
+        response = test_client.post("/stripe/create-checkout-session", json=data, headers=valid_auth_header)
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid redirect URL"
+        mock_service.assert_not_called()
+    test_client.app.dependency_overrides = {}
+
+
+def test_invalid_cancel_url_scheme(test_client, mock_supabase, valid_auth_header, mock_authenticate_user):
+    data = _request_data(mock_authenticate_user)
+    data["cancelUrl"] = "javascript:alert(1)"
+    test_client.app.dependency_overrides[utils.auth.get_current_user] = lambda: mock_authenticate_user
+    with patch('routes.stripe.create_checkout_session.stripe_service.create_checkout_session') as mock_service:
+        response = test_client.post("/stripe/create-checkout-session", json=data, headers=valid_auth_header)
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid redirect URL"
+        mock_service.assert_not_called()
+    test_client.app.dependency_overrides = {}


### PR DESCRIPTION
## Summary
- validate success and cancel URLs in Stripe checkout session route
- add dummy Stripe config in tests
- test invalid redirect schemes

## Testing
- `pytest tests/test_stripe.py -q -s`
- `pytest -q` *(fails: connection refused errors)*

------
https://chatgpt.com/codex/tasks/task_b_6875084f6a2c8325875069f0aceaa458