### PR TITLE
Store Stripe webhook events

### DIFF
--- a/routes/stripe/webhook.py
+++ b/routes/stripe/webhook.py
@@ -36,17 +36,13 @@ async def handle_stripe_webhook(
             logger.error("Invalid signature in webhook")
             raise HTTPException(status_code=400, detail="Invalid signature")
         
-        # Handle the event
-        event_type = event['type']
-        event_data = event['data']
-        
-        logger.info(f"Received webhook event: {event_type}")
-        
+        logger.info(f"Received webhook event: {event['type']}")
+
         # Process the event
-        success = await stripe_service.handle_webhook_event(event_type, event_data)
+        success = await stripe_service.handle_webhook_event(event)
         
         if not success:
-            logger.error(f"Failed to process webhook event: {event_type}")
+            logger.error(f"Failed to process webhook event: {event['type']}")
             raise HTTPException(status_code=500, detail="Failed to process webhook event")
         
         return {"success": True, "received": True}


### PR DESCRIPTION
## Summary
- save Stripe events into `stripe_webhook_events`
- log subscription status changes to `subscription_audit_log`
- include Stripe event data when updating user metadata
- update webhook route to pass full event object to service

## Testing
- `pytest tests/ > /tmp/pytest.log` *(fails: 26 failed)*

------
https://chatgpt.com/codex/tasks/task_b_68765c19ed1083259f2b91283248b7bf