### PR TITLE
Add subscription gating logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test_123")
 os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
 os.environ.setdefault("STRIPE_PLUS_MONTHLY_PRICE_ID", "price_monthly")
 os.environ.setdefault("STRIPE_PLUS_YEARLY_PRICE_ID", "price_yearly")
+os.environ.setdefault("STRIPE_PLUS_PRODUCT_ID", "plus")
 
 
 from main import app
@@ -35,7 +36,10 @@ def mock_supabase():
          patch("routes.prompts.templates.get_templates.supabase") as mock_get_templates_supabase, \
          patch("routes.user.supabase") as mock_user_supabase, \
          patch("utils.supabase_helpers.supabase") as mock_helpers_supabase, \
-         patch("utils.notification_service.supabase") as mock_notification_service_supabase:
+         patch("utils.notification_service.supabase") as mock_notification_service_supabase, \
+         patch("routes.prompts.templates.get_template_by_id.stripe_service.get_subscription_status") as mock_get_sub_status1, \
+         patch("routes.prompts.templates.create_template.stripe_service.get_subscription_status") as mock_get_sub_status2, \
+         patch("routes.prompts.blocks.create_block.stripe_service.get_subscription_status") as mock_get_sub_status3:
         
         # Configure all mocks to have the same behavior
         mocks = {
@@ -165,7 +169,12 @@ def mock_supabase():
                 
                 mock.get_user_templates = MagicMock()
                 mock.get_organization_templates = MagicMock()
-        
+
+        default_status = MagicMock(isActive=True, planId="plus")
+        mock_get_sub_status1.return_value = default_status
+        mock_get_sub_status2.return_value = default_status
+        mock_get_sub_status3.return_value = default_status
+
         yield mocks
 
 @pytest.fixture

--- a/tests/test_prompts_blocks.py
+++ b/tests/test_prompts_blocks.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, AsyncMock
 
 
 def test_get_blocks_published_filter(test_client, mock_supabase, valid_auth_header, mock_authenticate_user):
@@ -49,3 +49,20 @@ def test_get_blocks_search(test_client, mock_supabase, valid_auth_header, mock_a
     assert response.status_code == 200
     assert response.json()["success"] is True
     select_mock.or_.assert_any_call("title.ilike.%Search%,content.ilike.%Search%")
+
+
+def test_create_block_limit_paywall(test_client, mock_supabase, valid_auth_header, mock_authenticate_user):
+    count_response = MagicMock()
+    count_response.count = 5
+    count_response.data = [{}] * 5
+    mock_supabase["blocks"].table().select().eq().execute.return_value = count_response
+
+    sub_status = MagicMock(isActive=False, planId=None)
+    with patch('routes.prompts.blocks.create_block.stripe_service.get_subscription_status', AsyncMock(return_value=sub_status)):
+        response = test_client.post(
+            "/prompts/blocks/",
+            json={"type": "role", "title": "t", "content": "c"},
+            headers=valid_auth_header,
+        )
+
+    assert response.status_code == 402


### PR DESCRIPTION
## Summary
- restrict access to templates and blocks based on Plus subscription
- limit free users to 5 templates and 5 blocks
- add default Stripe mocks for tests
- unit tests for new paywall behaviour

## Testing
- `pytest -q` *(fails: Supabase configuration issues)*

------
https://chatgpt.com/codex/tasks/task_b_6878f0a7163c83259bfffb84b1bf66d8