### PR TITLE
Refactor onboarding checklist endpoint

### DIFF
--- a/routes/onboarding/checklist.py
+++ b/routes/onboarding/checklist.py
@@ -18,32 +18,28 @@ async def get_onboarding_checklist(
 ):
     """Get user's onboarding checklist status."""
     try:
-        # Get user metadata for onboarding tracking
-        metadata_response = supabase.table("users_metadata") \
-            .select("first_template_created, first_template_used, first_block_created, keyboard_shortcut_used, onboarding_dismissed") \
-            .eq("user_id", user_id) \
-            .single() \
+        # Fetch user metadata. `maybe_single` avoids errors when the record doesn't exist.
+        metadata_response = (
+            supabase.table("users_metadata")
+            .select(
+                "first_template_created, first_template_used, first_block_created, keyboard_shortcut_used, onboarding_dismissed"
+            )
+            .eq("user_id", user_id)
+            .maybe_single()
             .execute()
-        
-        # Default values if no metadata exists
+        )
+
         if metadata_response.data:
             metadata = metadata_response.data
         else:
-            # Create initial metadata record if it doesn't exist
-            initial_metadata = {
-                "user_id": user_id,
+            # No record yet; return defaults without creating a row
+            metadata = {
                 "first_template_created": False,
                 "first_template_used": False,
                 "first_block_created": False,
                 "keyboard_shortcut_used": False,
-                "onboarding_dismissed": False
+                "onboarding_dismissed": False,
             }
-            
-            insert_response = supabase.table("users_metadata") \
-                .insert(initial_metadata) \
-                .execute()
-            
-            metadata = initial_metadata
         
         first_template_created = metadata.get("first_template_created", False)
         first_template_used = metadata.get("first_template_used", False)

--- a/tests/test_onboarding_checklist.py
+++ b/tests/test_onboarding_checklist.py
@@ -1,0 +1,54 @@
+from unittest.mock import patch, MagicMock
+
+
+def _setup_supabase_mock(record):
+    """Create a side effect for supabase.table to return the given record."""
+
+    def table_side_effect(table_name):
+        table_mock = MagicMock()
+        select_mock = MagicMock()
+        eq_mock = MagicMock()
+        single_mock = MagicMock()
+        execute_mock = MagicMock()
+        execute_mock.data = record
+
+        table_mock.select.return_value = select_mock
+        select_mock.eq.return_value = eq_mock
+        eq_mock.maybe_single.return_value = single_mock
+        single_mock.execute.return_value = execute_mock
+        return table_mock
+
+    return table_side_effect
+
+
+def test_checklist_with_existing_metadata(test_client, valid_auth_header, mock_authenticate_user):
+    metadata = {
+        "first_template_created": True,
+        "first_template_used": False,
+        "first_block_created": True,
+        "keyboard_shortcut_used": False,
+        "onboarding_dismissed": False,
+    }
+
+    with patch("routes.onboarding.checklist.supabase") as supabase_mock:
+        supabase_mock.table.side_effect = _setup_supabase_mock(metadata)
+
+        response = test_client.get("/onboarding/checklist", headers=valid_auth_header)
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["first_template_created"] is True
+    assert data["completed_count"] == 2
+    assert data["total_count"] == 4
+
+
+def test_checklist_without_metadata(test_client, valid_auth_header, mock_authenticate_user):
+    with patch("routes.onboarding.checklist.supabase") as supabase_mock:
+        supabase_mock.table.side_effect = _setup_supabase_mock(None)
+
+        response = test_client.get("/onboarding/checklist", headers=valid_auth_header)
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["completed_count"] == 0
+    assert data["progress"] == "0/4"


### PR DESCRIPTION
## Summary
- speed up onboarding checklist endpoint by removing unneeded insert
- test the checklist endpoint

## Testing
- `pytest tests/test_onboarding_checklist.py -q`
- `pytest -q` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f8d15552c8320afb8468c489d022c