### PR TITLE
Add nested folder retrieval endpoint

### DIFF
--- a/routes/prompts/folders/__init__.py
+++ b/routes/prompts/folders/__init__.py
@@ -24,6 +24,7 @@ from .helpers import (
 )
 
 from . import get_folders
+from . import get_folder_by_id
 get_template_folders_by_type = fetch_folders_by_type
 from . import create_folder
 from . import update_folder
@@ -52,6 +53,7 @@ __all__ = [
     "update_pinned_folders_endpoint",
     "get_template_folders",
     "get_folders",
+    "get_folder_by_id",
     "get_template_folders_by_type",
     "fetch_folders_by_type",
     "fetch_templates_for_folders",

--- a/routes/prompts/folders/get_folder_by_id.py
+++ b/routes/prompts/folders/get_folder_by_id.py
@@ -1,0 +1,64 @@
+from typing import Optional, Dict, List
+from fastapi import Depends, HTTPException, Query, Request
+from models.common import APIResponse
+from utils import supabase_helpers
+from .helpers import router, supabase
+from .get_folders import build_nested_folder_structure, fetch_templates_for_all_folders
+from utils.prompts import process_folder_for_response, process_template_for_response
+from utils.access_control import apply_access_conditions, user_has_access_to_folder
+from utils.middleware.localization import extract_locale_from_request
+
+@router.get("/{folder_id}", response_model=APIResponse[Dict])
+async def get_folder_by_id(
+    folder_id: int,
+    request: Request,
+    withNested: bool = Query(False, description="Include nested folders and templates"),
+    user_id: str = Depends(supabase_helpers.get_user_from_session_token),
+) -> APIResponse[Dict]:
+    """Retrieve a folder by ID with optional nested structure."""
+    try:
+        locale = extract_locale_from_request(request)
+
+        access = user_has_access_to_folder(supabase, user_id, folder_id)
+        if access is None:
+            raise HTTPException(status_code=404, detail="Folder not found")
+        if not access:
+            raise HTTPException(status_code=403, detail="Access denied to this folder")
+
+        # Fetch the requested folder
+        query = supabase.table("prompt_folders").select("*").eq("id", folder_id)
+        query = apply_access_conditions(query, supabase, user_id)
+        response = query.single().execute()
+        if not response.data:
+            raise HTTPException(status_code=404, detail="Folder not found")
+
+        folder = process_folder_for_response(response.data, locale)
+
+        if not withNested:
+            return APIResponse(success=True, data=folder)
+
+        # Get all accessible folders to build hierarchy
+        all_folders_resp = supabase.table("prompt_folders").select("*")
+        all_folders_resp = apply_access_conditions(all_folders_resp, supabase, user_id)
+        all_folders = all_folders_resp.execute().data or []
+        processed_folders = [process_folder_for_response(f, locale) for f in all_folders]
+
+        folder_ids = [f["id"] for f in processed_folders]
+        templates_by_folder = await fetch_templates_for_all_folders(supabase, folder_ids, locale)
+
+        # Build nested structure starting from this folder
+        subfolders = await build_nested_folder_structure(
+            processed_folders, templates_by_folder, parent_folder_id=folder_id, with_templates=True
+        )
+
+        if templates_by_folder.get(folder_id):
+            folder["templates"] = templates_by_folder[folder_id]
+        if subfolders:
+            folder["subfolders"] = subfolders
+
+        return APIResponse(success=True, data=folder)
+
+    except Exception as e:
+        if isinstance(e, HTTPException):
+            raise e
+        raise HTTPException(status_code=500, detail=f"Error retrieving folder: {str(e)}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,11 @@ def mock_supabase():
          patch("routes.notifications.supabase") as mock_notifications_supabase, \
          patch("routes.prompts.supabase") as mock_prompts_supabase, \
          patch("routes.prompts.folders.supabase") as mock_folders_supabase, \
+         patch("routes.prompts.folders.helpers.supabase") as mock_folders_helpers_supabase, \
          patch("routes.prompts.templates.supabase") as mock_templates_supabase, \
+         patch("routes.prompts.templates.helpers.supabase") as mock_templates_helpers_supabase, \
          patch("routes.prompts.templates.get_templates.supabase") as mock_get_templates_supabase, \
+         patch("routes.prompts.blocks.helpers.supabase") as mock_blocks_helpers_supabase, \
          patch("routes.user.supabase") as mock_user_supabase, \
          patch("utils.supabase_helpers.supabase") as mock_helpers_supabase, \
          patch("utils.notification_service.supabase") as mock_notification_service_supabase, \
@@ -49,8 +52,11 @@ def mock_supabase():
             "notifications": mock_notifications_supabase,
             "prompts": mock_prompts_supabase,
             "folders": mock_folders_supabase,
+            "folders_helpers": mock_folders_helpers_supabase,
             "templates": mock_templates_supabase,
+            "templates_helpers": mock_templates_helpers_supabase,
             "get_templates": mock_get_templates_supabase,
+            "blocks_helpers": mock_blocks_helpers_supabase,
             "user": mock_user_supabase,
             "helpers": mock_helpers_supabase,
             "notification_service": mock_notification_service_supabase


### PR DESCRIPTION
## Summary
- implement `get_folder_by_id` route to fetch folders with optional nested content
- expose new route via folders package
- mock additional Supabase clients in tests
- add tests for folder-by-id endpoint

## Testing
- `pytest tests/test_prompts_folders.py::test_get_folder_by_id_without_nested -q`
- `pytest tests/test_prompts_folders.py::test_get_folder_by_id_with_nested -q`
- `pytest tests/test_prompts_folders.py::test_get_folder_by_id_not_found -q`
- `pytest -q` *(fails: 29 failed, 24 passed, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_687f9ca385408320ba36edf1b19706ff