### PR TITLE
Fix signup flow

### DIFF
--- a/routes/auth/refresh_token.py
+++ b/routes/auth/refresh_token.py
@@ -1,9 +1,10 @@
 from fastapi import HTTPException
-from . import router, supabase
+from . import router
 from .schemas import RefreshTokenData
 
 @router.post("/refresh_token")
 async def refresh_token(refresh_data: RefreshTokenData):
+    from . import supabase  # ensure patched supabase is used during tests
     """Refresh an expired access token using the refresh token."""
     try:
         response = supabase.auth.refresh_session(refresh_data.refresh_token)

--- a/routes/auth/sign_in.py
+++ b/routes/auth/sign_in.py
@@ -1,9 +1,10 @@
 from fastapi import HTTPException
-from . import router, supabase
+from . import router
 from .schemas import SignInData
 
 @router.post("/sign_in")
 async def sign_in(sign_in_data: SignInData):
+    from . import supabase  # ensure patched supabase is used during tests
     """Authenticate user via email & password."""
     try:
         response = supabase.auth.sign_in_with_password({

--- a/routes/auth/sign_in_with_google.py
+++ b/routes/auth/sign_in_with_google.py
@@ -1,6 +1,6 @@
 # routes/auth/sign_in_with_google.py - Updated
 from fastapi import HTTPException
-from . import router, supabase
+from . import router
 from .schemas import GoogleAuthRequest
 from utils.notification_service import NotificationService
 import logging
@@ -12,6 +12,7 @@ JAYDAI_ORG_ID = "19864b30-936d-4a8d-996a-27d17f11f00f"
 
 @router.post("/sign_in_with_google")
 async def sign_in_with_google(google_sign_in_data: GoogleAuthRequest):
+    from . import supabase  # ensure patched supabase is used during tests
     """Authenticate user via Google OAuth with automatic starter pack for new users."""
     try:
         response = supabase.auth.sign_in_with_id_token({


### PR DESCRIPTION
## Summary
- adjust auth modules to dynamically import supabase so tests can mock it
- rework signup to use standard `auth.sign_up` and reuse returned session

## Testing
- `pytest tests/test_auth.py -q`
- `pytest -q` *(fails: IndexError: list index out of range)*

------
https://chatgpt.com/codex/tasks/task_e_687fc693aba48320a0bb5a7256b4d525