### PR TITLE
Fix cancel subscription for trial users

### DIFF
--- a/services/stripe/subscriptions/cancel_subscription.py
+++ b/services/stripe/subscriptions/cancel_subscription.py
@@ -7,12 +7,51 @@ logger = logging.getLogger(__name__)
 
 async def cancel_subscription(supabase: Client, user_id: str) -> bool:
     try:
-        sub_resp = supabase.table("stripe_subscriptions").select("stripe_subscription_id").eq("user_id", user_id).in_("status", ["active", "trialing"]).execute()
-        if not sub_resp.data:
-            logger.warning("No active or trialing subscription found for user %s", user_id)
+        sub_resp = (
+            supabase.table("stripe_subscriptions")
+            .select("stripe_subscription_id")
+            .eq("user_id", user_id)
+            .in_("status", ["active", "trialing"])
+            .execute()
+        )
+
+        subscription_id = None
+        if sub_resp.data:
+            subscription_id = sub_resp.data[0]["stripe_subscription_id"]
+        else:
+            logger.info(
+                "Subscription not found in DB for user %s, checking Stripe", user_id
+            )
+            meta_resp = (
+                supabase.table("users_metadata")
+                .select("stripe_customer_id")
+                .eq("user_id", user_id)
+                .single()
+                .execute()
+            )
+            customer_id = meta_resp.data.get("stripe_customer_id") if meta_resp.data else None
+            if customer_id:
+                try:
+                    subs = stripe.Subscription.list(
+                        customer=customer_id, status="all", limit=1
+                    )
+                    if subs.data:
+                        stripe_sub = subs.data[0]
+                        if stripe_sub.status in ["active", "trialing"]:
+                            subscription_id = stripe_sub.id
+                except stripe.error.StripeError as e:
+                    logger.error("Stripe error retrieving subscription: %s", e)
+                    return False
+
+        if not subscription_id:
+            logger.warning(
+                "No active or trialing subscription found for user %s", user_id
+            )
             return False
-        subscription_id = sub_resp.data[0]["stripe_subscription_id"]
-        subscription = stripe.Subscription.modify(subscription_id, cancel_at_period_end=True)
+
+        subscription = stripe.Subscription.modify(
+            subscription_id, cancel_at_period_end=True
+        )
         await update_subscription_status(supabase, user_id, subscription)
         logger.info("Cancelled subscription %s for user %s", subscription_id, user_id)
         return True


### PR DESCRIPTION
## Summary
- handle missing subscription records when cancelling
- check Stripe directly if DB doesn't have active/trialing subscription

## Testing
- `pytest -q`
- `pytest tests/test_stripe.py::test_invalid_success_url_scheme -q`

------
https://chatgpt.com/codex/tasks/task_e_688213393af483209c4e5deea8fc4b7f