### PR TITLE
Add Amplitude events for Stripe actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ STRIPE_WEBHOOK_SECRET=change-me
 STRIPE_PLUS_MONTHLY_PRICE_ID=price_monthly_dummy
 STRIPE_PLUS_YEARLY_PRICE_ID=price_yearly_dummy
 SENTRY_DSN=your-sentry-dsn
+AMPLITUDE_API_KEY=your-amplitude-api-key
 
 # Paths only - these will be appended to chrome.identity.getRedirectURL()
 VITE_STRIPE_SUCCESS_URL=/stripe/success

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ STRIPE_WEBHOOK_SECRET=<your-stripe-webhook-secret>
 STRIPE_PLUS_MONTHLY_PRICE_ID=<your-stripe-monthly-price-id>
 STRIPE_PLUS_YEARLY_PRICE_ID=<your-stripe-yearly-price-id>
 SENTRY_DSN=<your-sentry-dsn>
+AMPLITUDE_API_KEY=<your-amplitude-api-key>
 ```
 
 The Chrome extension's frontend also requires Stripe URLs that integrate with

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,3 +66,4 @@ yarl==1.18.3
 stripe==12.3.0
 PyJWT>=2.6.0
 sentry-sdk>=1.45.0
+amplitude-analytics==1.6.2

--- a/services/stripe/checkout/verify_checkout_session.py
+++ b/services/stripe/checkout/verify_checkout_session.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 import stripe
 from supabase import Client
 from services.stripe.subscriptions import get_subscription_status, update_subscription_status
+from utils.amplitude import track_event
 
 logger = logging.getLogger(__name__)
 
@@ -10,18 +11,32 @@ async def verify_checkout_session(supabase: Client, session_id: str) -> Dict[str
     """Verify a checkout session and return subscription details."""
     try:
         session = stripe.checkout.Session.retrieve(session_id, expand=["subscription"])
-        if session.payment_status != "paid":
-            return {"success": False, "error": "Payment not completed"}
         user_id = session.metadata.get("user_id")
+        if session.payment_status != "paid":
+            if user_id:
+                track_event(user_id, "payment_failed", {"session_id": session_id})
+            return {"success": False, "error": "Payment not completed"}
+
         if not user_id:
             return {"success": False, "error": "User ID not found in session metadata"}
+
         if session.subscription:
             await update_subscription_status(supabase, user_id, session.subscription)
+
         sub_status = await get_subscription_status(supabase, user_id)
+        track_event(user_id, "payment_succeeded", {"session_id": session_id})
         return {"success": True, "subscription": sub_status}
     except stripe.error.StripeError as e:
         logger.error("Stripe error verifying session: %s", e)
+        if 'session' in locals():
+            user_id = session.metadata.get("user_id") if session and session.metadata else None
+            if user_id:
+                track_event(user_id, "payment_failed", {"session_id": session_id, "error": str(e)})
         return {"success": False, "error": f"Payment verification failed: {e}"}
     except Exception as e:  # pragma: no cover - unexpected
         logger.error("Unexpected error verifying session: %s", e)
+        if 'session' in locals():
+            user_id = session.metadata.get("user_id") if session and session.metadata else None
+            if user_id:
+                track_event(user_id, "payment_failed", {"session_id": session_id, "error": str(e)})
         return {"success": False, "error": "An unexpected error occurred"}

--- a/services/stripe/webhooks/handle_webhook_event.py
+++ b/services/stripe/webhooks/handle_webhook_event.py
@@ -5,6 +5,7 @@ from supabase import Client
 
 from .record_webhook_event import record_webhook_event
 from .process_webhook_event import process_webhook_event
+from utils.amplitude import track_event
 
 logger = logging.getLogger(__name__)
 
@@ -13,6 +14,9 @@ async def handle_webhook_event(supabase: Client, event: Dict[str, Any]) -> bool:
     event_id = event.get("id")
     event_type = event.get("type")
     event_data = event.get("data", {})
+
+    user_id = event_data.get("object", {}).get("metadata", {}).get("user_id")
+    track_event(user_id or "unknown", "stripe_webhook_event", {"event_type": event_type})
 
     existing = supabase.table("stripe_webhook_events").select("id, processed").eq("stripe_event_id", event_id).maybe_single().execute()
     if existing and existing.data and existing.data.get("processed"):

--- a/utils/amplitude.py
+++ b/utils/amplitude.py
@@ -1,0 +1,21 @@
+import os
+import logging
+try:
+    from amplitude import Amplitude, BaseEvent
+except Exception:  # pragma: no cover - amplitude optional
+    Amplitude = None
+    BaseEvent = None
+
+_API_KEY = os.getenv("AMPLITUDE_API_KEY")
+_client = Amplitude(_API_KEY) if _API_KEY and Amplitude else None
+logger = logging.getLogger(__name__)
+
+def track_event(user_id: str, event_type: str, event_properties: dict | None = None):
+    """Send an event to Amplitude if configured."""
+    if not _client:
+        return
+    try:
+        event = BaseEvent(event_type=event_type, user_id=user_id, event_properties=event_properties or {})
+        _client.track(event)
+    except Exception as e:  # pragma: no cover - network issues
+        logger.error("Failed to send amplitude event %s for user %s: %s", event_type, user_id, e)


### PR DESCRIPTION
## Summary
- add Amplitude analytics dependency
- expose `AMPLITUDE_API_KEY` env var
- implement `utils/amplitude.track_event`
- send payment events on checkout verification
- log webhook events to Amplitude and add events on payment success/failure

## Testing
- `pytest -q` *(fails: 27 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68823b5402e483208927b8820f64e7d6